### PR TITLE
Builder scripts for aarch64 build server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+on:
+  pull_request:
+
+jobs:
+  direct:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ludeeus/action-shellcheck@1.1.0

--- a/README.md
+++ b/README.md
@@ -172,3 +172,24 @@ docker buildx build \
 Note that the image will be on GitHub but *not* your local docker. lol.
 Docker is a mess. Supposedly replacing ``-push` with `--output=docker` would
 fix this but for me: it did nothing.
+
+Cross-running multi-arch images
+===============================
+
+If you're even crazier, you can run the alternate architectures using docker's QEMU emulation:
+
+(N.B. This will be slow.)
+
+```sh
+docker run \
+  --hostname tea \
+  --interactive --tty \
+  --volume /opt/tea.xyz/var/www:/opt/tea.xyz/var/www \
+  --volume $PWD/pantry:/opt/tea.xyz/var/pantry \
+  --volume $PWD/cli:/opt/tea.xyz/var/cli \
+  --workdir /opt/tea.xyz/var/pantry \
+  --platform linux/amd64 \
+  --env GITHUB_TOKEN \
+  ghcr.io/teaxyz/infuser:latest \
+  /bin/bash
+```

--- a/scripts/build-infuser.sh
+++ b/scripts/build-infuser.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if test ! -d /opt/tea.xyz/var/infuser -o ! -d /opt/tea.xyz/var/cli -o ! -d /opt/tea.xyz/var/pantry; then
+  echo "Missing one of the three required repositories"
+  exit 1
+fi
+
+cd /opt/tea.xyz/var/infuser
+
+git status -uno | grep "Your branch is up to date with 'origin/main'." && exit
+
+git reset --hard
+git fetch origin
+git pull --rebase
+
+eval "$(grep ^GITHUB_TOKEN= ~/docker.env.tea)"
+
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u jhheider --password-stdin
+
+docker buildx build \
+  --pull --push \
+  --tag ghcr.io/teaxyz/infuser:latest \
+  --tag ghcr.io/teaxyz/infuser::"$(git -C infuser branch --show-current)" \
+  --tag ghcr.io/teaxyz/infuser:sha-"$(git -C infuser rev-parse --short HEAD)" \
+  --platform linux/amd64,linux/arm64 \
+  --file infuser/Dockerfile \
+  --build-arg GITHUB_TOKEN="$GITHUB_TOKEN" \
+  --progress=plain \
+  .

--- a/scripts/build-test-bottle-upload.sh
+++ b/scripts/build-test-bottle-upload.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cd /opt/tea.xyz/var/pantry
+
+## Ensure clean environments
+find /opt -maxdepth 1 -mindepth 1 -type d ! -name tea.xyz -exec rm -rf {} \;
+if test -d /opt/tea.xyz/var/www; then
+  find /opt/tea.xyz/var/www/ -type f -exec rm {} \;
+fi
+
+if test $# -eq 1; then
+  PACKAGE_SPEC=$1
+else
+  PACKAGE_SPEC=$1@$2
+fi
+
+REQS=$(GITHUB_ACTIONS=1 ./scripts/sort.ts "$PACKAGE_SPEC" | sed -ne 's/::set-output name=pre-install:://p')
+
+if test ! -z "$REQS"; then
+  # shellcheck disable=SC2086
+  # We want to split on spaces here
+  ./scripts/install.ts $REQS
+fi
+
+BUILT=$(./scripts/build.ts "$PACKAGE_SPEC" | sed -ne 's/::set-output name=pkgs:://p')
+
+# As designed, there will only be one package built per invocation,
+# but that's no reason to assume it will always be that way.
+for PKG in $BUILT; do
+  ./scripts/test.ts "$PKG"
+
+  FILES=$(./scripts/bottle.ts "$PKG" | sed -ne 's/::set-output name=bottles:://p')
+
+  # shellcheck disable=SC2086
+  ./scripts/upload.ts $FILES
+done

--- a/scripts/dispatch.sh
+++ b/scripts/dispatch.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+LOCKFILE=/tmp/dispatch.sh.lock
+
+if ! shlock -f "$LOCKFILE" -p $$; then
+  exit
+fi
+
+trap "rm \\"$LOCKFILE\\"" EXIT
+
+function update_from_git() {
+  git reset --hard
+  git fetch origin
+  git checkout main
+  git pull --rebase
+}
+
+## BEGIN
+PACKAGE=$(curl -s https://app.tea.xyz/api/builder/nextJob -H "authorization: bearer $TOKEN" | \
+ sed -e 's/{"project":"\(.*\)","version":"\(.*\)"}/\1 \2/' -e 's/ \*$//')
+
+if test -z "$PACKAGE"; then
+  exit 0
+fi
+
+cd /opt/tea.xyz/var/cli
+update_from_git
+cd ../pantry
+update_from_git
+
+set -a
+# shellcheck source=/dev/null
+. ~/docker.env.tea
+
+# shellcheck disable=SC2086
+/opt/tea.xyz/var/infuser/scripts/build-test-bottle-upload.sh $PACKAGE >/opt/tea.xyz/var/log/build-log-aarch64.log 2>&1
+
+docker container prune --force
+
+# shellcheck disable=SC2086
+docker run \
+  --hostname tea \
+  --interactive --tty \
+  --volume /opt/tea.xyz/var/pantry:/opt/tea.xyz/var/pantry \
+  --volume /opt/tea.xyz/var/cli:/opt/tea.xyz/var/cli \
+  --volume /opt/tea.xyz/var/infuser/scripts:/opt/tea.xyz/var/infuser/scripts \
+  --workdir /opt/tea.xyz/var/pantry \
+  --env-file ~/docker.env.tea \
+  ghcr.io/teaxyz/infuser:latest \
+  /opt/tea.xyz/var/infuser/scripts/build-test-bottle-upload.sh $PACKAGE \
+  >/opt/tea.xyz/var/log/build-log-x86_64.log 2>&1
+
+#TODO: add slack notification


### PR DESCRIPTION
I _think_ these might actually be working. Getting some build failures on linux/aarch64 (ninja-build for example, claims to be missing libcurl.so.4) but they are passing most tests. I do have to keep re-queueing packages, since we're way behind on linux/aarch64, but the next rebuild will handle that. And the infuser builder will need to be tested for 5 hours with the next push to infuser.

@mxcl any crazy concerns before I start running these every minute?

- [x] build darwin/aarch64 binaries
- [x] build linux/aarch64 binaries
- [x] build infuser for all arches and push
- [x] use AWS CloudWatch agent to stream logs to AWS
- [x] `shellcheck` all scripts on push
- [x] `README.md` instructions for cross-platform infuser